### PR TITLE
Circumvent the NullReferenceException

### DIFF
--- a/nSpotify/Data/Resource.cs
+++ b/nSpotify/Data/Resource.cs
@@ -51,7 +51,7 @@ namespace nSpotify
         /// </returns>
         public static bool operator ==(Resource left, Resource right)
         {
-            return left.Name == right.Name && left.InternalUri == right.InternalUri;
+            return left?.Name == right?.Name && left?.InternalUri == right?.InternalUri;
         }
 
         /// <summary>


### PR DESCRIPTION
Adds the return value question mark to work around a NullReferenceException.
