### PR TITLE
Circumvent the NullReferenceException

### DIFF
--- a/nSpotify/Data/Track.cs
+++ b/nSpotify/Data/Track.cs
@@ -26,7 +26,7 @@ namespace nSpotify
         {
             get
             {
-                return this.TrackResource.Name;
+                return this.TrackResource?.Name;
             }
         }
 
@@ -49,7 +49,7 @@ namespace nSpotify
         {
             get
             {
-                return this.ArtistResource.Name;
+                return this.ArtistResource?.Name;
             }
         }
 
@@ -72,7 +72,7 @@ namespace nSpotify
         {
             get
             {
-                return this.AlbumResource.Name;
+                return this.AlbumResource?.Name;
             }
         }
 
@@ -114,7 +114,7 @@ namespace nSpotify
         /// </returns>
         public static bool operator ==(Track left, Track right)
         {
-            return left.TrackResource == right.TrackResource && left.ArtistResource == right.ArtistResource && left.AlbumResource == right.AlbumResource && left.Length == right.Length && left.Type == right.Type;
+            return (object)right != null && left.TrackResource == right.TrackResource && left.ArtistResource == right.ArtistResource && left.AlbumResource == right.AlbumResource && left.Length == right.Length && left.Type == right.Type;
         }
 
         /// <summary>
@@ -173,7 +173,7 @@ namespace nSpotify
         {
             using (WebClient client = new WebClient() { Proxy = null })
             {
-                string source = client.DownloadString(string.Format("http://open.spotify.com/album/{0}", this.AlbumResource.InternalUri.AbsolutePath.Split(':')[1])).Replace("\t", string.Empty);
+                string source = client.DownloadString(string.Format("http://open.spotify.com/album/{0}", this.AlbumResource?.InternalUri?.AbsolutePath?.Split(':')[1])).Replace("\t", string.Empty);
                 foreach (string line in source.Split('\r', '\n'))
                 {
                     if (line.StartsWith("<meta property=\"og:image\""))


### PR DESCRIPTION
Adds the return value question mark to work around a NullReferenceException.
